### PR TITLE
Fixed reordering tabs not working on Windows

### DIFF
--- a/src/components/Content/Editor/EditorTabs.svelte
+++ b/src/components/Content/Editor/EditorTabs.svelte
@@ -5,7 +5,6 @@
     import { tabs, hidden } from "./scripts/Tabs";
 
     let tabcontainer;
-    // TODO: Get this to work
     onMount(() => {
         Sortable.create(tabcontainer, {
             draggable: ".tab",

--- a/src/components/Content/Editor/EditorTabs.svelte
+++ b/src/components/Content/Editor/EditorTabs.svelte
@@ -10,6 +10,7 @@
         Sortable.create(tabcontainer, {
             draggable: ".tab",
             animation: 150,
+            forceFallback: true,
             easing: "cubic-bezier(1, 0, 0, 1)",
             sort: true
         })


### PR DESCRIPTION
Fix for #2 
Tab reordering with SortableJs doesn't work on Windows because apparently pointer events doesn't work on Edge/Firefox (Edge is the browser Tauri depends on for rendering on Windows). All that was needed was forcing the behavior to rely on another method via fallback ([found issue here](https://github.com/SortableJS/Sortable/issues/685), [docs here](https://github.com/SortableJS/Sortable#options)).