### PR TITLE
Fixes infinite opening of file dialog

### DIFF
--- a/src/components/FileTree/scripts/TreeData.ts
+++ b/src/components/FileTree/scripts/TreeData.ts
@@ -2,14 +2,17 @@ import { dialog, fs } from "@tauri-apps/api";
 import { sep } from "@tauri-apps/api/path";
 import { writable } from "svelte/store";
 import { filetree } from "./TreeStore";
+import { homeDir } from '@tauri-apps/api/path';
 let parentname: string;
 let dir;
+var path: string;
 export let loadingtree = writable(false);
 export async function data() {
     let dirname = await dialog.open({ directory: true }) as string;
     if (dirname === undefined || dirname === null) return;
     dir = dirname;
     loadingtree.set(true);
+    globalThis.path = dir;
     return await loadTree();
 }
 
@@ -69,3 +72,11 @@ function buildTree(children: fs.FileEntry[]) {
     }
     return nodes;
 }
+
+// function for getting the absolute path of tree
+export function get_path() {
+    let userpath = homeDir();
+    if (dir != undefined || dir != null) return dir;
+    return userpath;
+}
+

--- a/src/components/FileTree/scripts/TreeData.ts
+++ b/src/components/FileTree/scripts/TreeData.ts
@@ -7,7 +7,7 @@ let dir;
 export let loadingtree = writable(false);
 export async function data() {
     let dirname = await dialog.open({ directory: true }) as string;
-    if (dirname === null) return;
+    if (dirname === undefined || dirname === null) return;
     dir = dirname;
     loadingtree.set(true);
     return await loadTree();

--- a/src/components/Footer/Footer.svelte
+++ b/src/components/Footer/Footer.svelte
@@ -2,13 +2,12 @@
     import { Notification, Terminal, Unlocked } from "carbon-icons-svelte"
     import { isfile } from "../Tabs/scripts/Tab";
     import { invoke } from "@tauri-apps/api/tauri";
-    import { homeDir } from '@tauri-apps/api/path';
-    import { filetree } from "../FileTree/scripts/TreeStore";
     import LanguageList from "./LanguageList.svelte";
     import { languages } from "@codemirror/language-data";
     import { file_language, file_linefeed, line_info } from "../Editor/scripts/Editor";
     import Notifications from "../Notifications/Notifications.svelte";
     import { unreadnotifications } from "../Notifications/Notifications";
+    import { get_path } from "../FileTree/scripts/TreeData";
 
     let langs = [];
     for (let l of languages) {
@@ -21,12 +20,8 @@
     ]
 
     async function spawnTerminal() {
-        let userpath = await homeDir();
-        if ($filetree.length > 0) {
-            userpath = $filetree[0].path;
-        }
-        // opens terminal externally for the time being
-        invoke("open_terminal", {path: userpath});
+        let userpath_tree = await get_path();
+        invoke("open_terminal", {path: userpath_tree});
     }
 </script>
 
@@ -34,7 +29,7 @@
     import { writable } from "svelte/store";
     export let showpanel = writable(false);
     let show = false;
-    
+
     export let tool = writable({name: "", content: null});
 
     export function togglePanel(x = null) {
@@ -55,7 +50,7 @@
     <div id="tools">
         <!-- svelte-ignore a11y-click-events-have-key-events -->
         <span class="tool" on:click={spawnTerminal}>
-            <Terminal /> 
+            <Terminal />
             <span class="toolname">Terminal</span>
         </span>
         {#each tools as tool}
@@ -166,7 +161,7 @@
         border-right: 1px solid #393939;
         border-left: 1px solid #393939;
     }
-    
+
     #apptitle {
         padding: 0 15px;
     }

--- a/src/components/Header/header_menus/FileMenu.ts
+++ b/src/components/Header/header_menus/FileMenu.ts
@@ -9,21 +9,20 @@ export async function addNewFile() {
 }
 export async function openFile() {
     let path = await getFile();
-    if (path === undefined) return;
+    if (path === undefined || path === null) return;
     await addFileTab(path);
 }
+
 export async function openFolder() {
     let treedata = await data();
-    if (treedata === undefined) {
-        loadingtree.set(false);
-        return;
-    }
+    if (treedata === undefined || treedata === null) return;
     filetree.set(treedata);
     workspacename.set(workspace());
     loadingtree.set(false);
+    return;
 }
 export async function saveOpenFile() {
-    await saveFile()
+    await saveFile();
 }
 export async function saveOpenFileAs() {
     await saveFileAs();

--- a/src/components/Header/menu.ts
+++ b/src/components/Header/menu.ts
@@ -6,7 +6,7 @@ import { shell } from "@tauri-apps/api";
 const shortcuts = settings.shortcuts;
 
 export const filemenu = [
-    { option: "New File...", shortcut: getShortcut(shortcuts["new-file-shortcut"]), onclick: addNewFile },
+    { option: "New File...", shortcut: getShortcut(shortcuts["new-file-shortcut"]), onclick: addNewFile  },
     { option: "Open File...", shortcut: getShortcut(shortcuts["open-file-shortcut"]), onclick: openFile },
     { option: "Open Folder", shortcut: getShortcut(shortcuts["open-folder-shortcut"]), onclick: openFolder },
     { option: "Open Recent", onclick: () => { console.log("click"); } },

--- a/src/scripts/EditorFile.ts
+++ b/src/scripts/EditorFile.ts
@@ -24,7 +24,7 @@ export class EditorFile {
 }
 export async function getFile() {
     let path = await dialog.open() as string;
-    if (path === null) return;
+    if (path === null || path === undefined) return;
     return path;
 }
 export async function getFileData(path = "", label = "") {


### PR DESCRIPTION
I have, 

1. Fixed the infinite opening of file dialog (occurs when closed dialog with cross and switched to another program)
2. Added fucntion to get absolute path of directory opened in Filetree if not than return the home dir (for "open_terminal" functionality)